### PR TITLE
Feature/delete post from index after status change

### DIFF
--- a/multisite-search.php
+++ b/multisite-search.php
@@ -97,7 +97,7 @@ $wpdb->multisite_search = $wpdb->base_prefix . 'multisite_search';
 multisite_search()
 	->register_component( new \MultisiteSearch\Admin\Priority_Keywords_Meta() )
 	->register_component( new \MultisiteSearch\API\Search() )
-	->register_component( new \MultisiteSearch\Hooks\Post_Type() )
+	->register_component( new \MultisiteSearch\Hooks\Post_Type( new \MultisiteSearch\Admin\Index() ) )
 	->register_component( new \MultisiteSearch\Hooks\Search_Results() )
 	->register_component( new \MultisiteSearch\View\Search_Box() )
 	->register_component( new \MultisiteSearch\View\Network_Admin_Menu() );

--- a/php/Admin/class-index.php
+++ b/php/Admin/class-index.php
@@ -195,4 +195,19 @@ class Index {
 
 		return in_array( $type, $post_types, true );
 	}
+
+	/**
+	 * Remove a post from the index.
+	 * 
+	 * @param int $post_id Post ID.
+	 * 
+	 * @return boolean $result.
+	 */
+	public function remove_post_from_index( $post_id ) {
+		global $wpdb;
+
+		$result = $wpdb->delete( $wpdb->multisite_search, array( 'post_id' => $post_id ) ); //phpcs:ignore
+
+		return $result;
+	}
 }

--- a/php/Admin/class-index.php
+++ b/php/Admin/class-index.php
@@ -8,12 +8,14 @@
 
 namespace MultisiteSearch\Admin;
 
+use \MultisiteSearch\IndexerInterface;
 use \MultisiteSearch\Utility\Logger;
+
 
 /**
  * Database maintainance class.
  */
-class Index {
+class Index implements IndexerInterface {
 
 	/**
 	 * Add a given site to the Multisite Search Index.

--- a/php/Hooks/class-post-type.php
+++ b/php/Hooks/class-post-type.php
@@ -22,6 +22,24 @@ class Post_Type extends ComponentAbstract {
 	 */
 	public function register_hooks() {
 		add_action( 'wp_insert_post', array( $this, 'index_post' ), 10, 3 );
+		add_action( 'transition_post_status', array( $this, 'remove_post' ), 10, 3 );
+	}
+
+	/**
+	 * Remove a post when its status is no longer published.
+	 * 
+	 * @param string  $new_status new post status.
+	 * @param string  $old_status old post status.
+	 * @param WP_Post $post_obj WP_Post object.
+	 * 
+	 * @return boolean
+	 */
+	public function remove_post( $new_status, $old_status, $post_obj ) {
+		if ( $new_status === $old_status || 'publish' === $new_status ) {
+			return;
+		}
+
+		return $this->indexer->remove_post_from_index( $post_obj->ID );
 	}
 
 	/**

--- a/php/Hooks/class-post-type.php
+++ b/php/Hooks/class-post-type.php
@@ -9,12 +9,28 @@
 namespace MultisiteSearch\Hooks;
 
 use MultisiteSearch\ComponentAbstract;
+use MultisiteSearch\IndexerInterface;
 
 /**
  * Class Post_Type
  */
 class Post_Type extends ComponentAbstract {
-
+	/**
+	 * Instance of the Indexer component.
+	 *
+	 * @var IndexerInterface
+	 */
+	private $indexer;
+	
+	/**
+	 * Constructor.
+	 * 
+	 * @param IndexerInterface $indexer Indexer.
+	 */
+	public function __construct( IndexerInterface $indexer ) {
+		$this->indexer = $indexer;
+	}
+	
 	/**
 	 * Register hooks for this view.
 	 *
@@ -58,7 +74,7 @@ class Post_Type extends ComponentAbstract {
 		}
 
 		$blog_id = \get_current_blog_id();
-		$indexer = new \MultisiteSearch\Admin\Index();
-		$indexer->index_post( $blog_id, $post );
+		
+		$this->indexer->index_post( $blog_id, $post );
 	}
 }

--- a/php/class-indexerinterface.php
+++ b/php/class-indexerinterface.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Indexer interface.
+ *
+ * @package   MultisiteSearch
+ * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
+ */
+
+namespace MultisiteSearch;
+
+/**
+ * Interface IndexerInterface
+ */
+interface IndexerInterface {
+
+	/**
+	 * Remove a post from the index.
+	 * 
+	 * @param int $post_id Post ID.
+	 *
+	 * @return void
+	 */
+	public function remove_post_from_index( $post_id );
+
+	/**
+	 * Add a given post to the Multisite Search Index.
+	 *
+	 * @param int  $blog_id The site to index.
+	 * @param int  $post_id The post to index.
+	 * @param bool $validated Whether post type has been validated.
+	 *
+	 * @return void
+	 */
+	public function index_post( $blog_id, $post_id, $validated = false );
+}


### PR DESCRIPTION
This PR includes a feature for removing a post from the index table (`wp_multisite_search`) when it becomes non-public*.

*non-public refers to when a post status transitions from `publish` to something non-public like `draft` or `trash`.